### PR TITLE
Fix runfiles collection for `nickle_export`

### DIFF
--- a/nickel/defs.bzl
+++ b/nickel/defs.bzl
@@ -50,7 +50,7 @@ def _nickel_export_impl(ctx):
 
     runfiles = _collect_runfiles(
         ctx,
-        direct_files = [ctx.file.src],
+        direct_files = ctx.files.deps + [ctx.file.src],
         indirect_targets = ctx.attr.deps,
     )
 


### PR DESCRIPTION
Rule `nickel_export` does not correctly collect transitive runfiles. In this PR, we are reusing [_collect_runfiles](https://github.com/jayconrod/rules_go_simple/blob/43b692d481140486513b00f862fbde9938f90a77/internal/rules.bzl#L323) from [writing-bazel-rules-data-and-runfiles](https://jayconrod.com/posts/108/writing-bazel-rules-data-and-runfiles) with a little modification (described in inline comment).

Original and new behavior can be seen/tested with [runfiles_collect example](https://github.com/uhlajs/rules_nickel/tree/bugfix/runfiles_collect_example/examples/runfiles_collect) in [runfiles_collect_example](https://github.com/uhlajs/rules_nickel/tree/bugfix/runfiles_collect_example) branch.